### PR TITLE
enable signup with email link

### DIFF
--- a/app/ui/email-link-signup-form.tsx
+++ b/app/ui/email-link-signup-form.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useActionState } from "react";
+import { signupWithEmailLink } from "@/app/lib/actions";
+import { useRedirectPath } from "@/app/lib/hooks/login/useRedirectPath";
+import { useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod";
+import { emailLinkLoginSchema } from "@/app/lib/schema/login/schema";
+import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
+
+export default function EmailLinkSignupForm() {
+  const [lastResult, action] = useActionState(
+    signupWithEmailLink.bind(null, useRedirectPath()),
+    undefined
+  );
+  const [form, fields] = useForm({
+    lastResult,
+
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: emailLinkLoginSchema });
+    },
+
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onInput",
+  });
+
+  return (
+    <form id={form.id} onSubmit={form.onSubmit} action={action} noValidate>
+      <div className="flex flex-col gap-6">
+        <div className="grid gap-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            key={fields.email.key}
+            type="email"
+            name={fields.email.name}
+            placeholder="Enter your email address"
+            defaultValue={fields.email.value}
+          />
+          {fields.email.errors && (
+            <div className="text-red-500 text-sm">{fields.email.errors}</div>
+          )}
+        </div>
+        <Button type="submit" className="w-full">
+          登録
+        </Button>
+        {form.errors && (
+          <div
+            aria-live="polite"
+            aria-atomic="true"
+            className="flex justify-center items-center space-x-1"
+          >
+            <ExclamationCircleIcon className="w-5 text-red-500" />
+            <p className="text-sm text-red-500">{form.errors}</p>
+          </div>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/components/signup-form.tsx
+++ b/components/signup-form.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import EmailLinkForm from "@/app/ui/email-link-form";
 import GithubAuthForm from "@/app/ui/github-auth-form";
 import AuthFormHeader from "./auth-form-header";
 import MyServiceName from "./my-service-name";
+import EmailLinkSignupForm from "@/app/ui/email-link-signup-form";
 
 export function SignUpForm({
   className,
@@ -25,7 +25,7 @@ export function SignUpForm({
             </a>
           </div>
         </div>
-        <EmailLinkForm />
+        <EmailLinkSignupForm />
         <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
           <span className="relative z-10 bg-background px-2 text-muted-foreground">
             Or


### PR DESCRIPTION
This pull request introduces a new email link signup feature and updates the signup form to incorporate this new functionality. The key changes include the addition of a new function for handling email link signups, a new UI component for the signup form, and updates to the existing signup form to use the new component.

New feature implementation:

* [`app/lib/actions.ts`](diffhunk://#diff-35bfb3f36c58eecbd06b0e96cb208a94a83d78fe67679bd7a0792e58341e8b4aR112-R154): Added a new function `signupWithEmailLink` to handle the signup process using an email link. This includes form data validation, user existence check, and error handling.

UI updates:

* [`app/ui/email-link-signup-form.tsx`](diffhunk://#diff-1ca2e65ff214f59451c9f0e2d65445c2c3b3846bbfdaaf56863b9996a0e405e3R1-R62): Created a new component `EmailLinkSignupForm` to handle the email link signup form UI. This includes form validation, input handling, and error display.
* [`components/signup-form.tsx`](diffhunk://#diff-d4e1404be15e63c46547e0a6a5f5597b7c7f553fb68d3c99b58c7e28c52a274eL4-R7): Updated the `SignUpForm` component to replace the existing email link form with the new `EmailLinkSignupForm` component. [[1]](diffhunk://#diff-d4e1404be15e63c46547e0a6a5f5597b7c7f553fb68d3c99b58c7e28c52a274eL4-R7) [[2]](diffhunk://#diff-d4e1404be15e63c46547e0a6a5f5597b7c7f553fb68d3c99b58c7e28c52a274eL28-R28)