### PR TITLE
Add e2e 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,35 @@
 FROM oven/bun:latest
 
-# create user
+# 一般的なセキュリティ対策として、アプリユーザーの追加。
+# コピーしたファイル/フォルダの権限は、作成したユーザー:グループの権限とする
 ARG username=vscode
 ARG useruid=1001
 ARG usergid=${useruid}
 RUN groupadd --gid ${usergid} ${username} \
 && useradd -s /bin/bash --uid ${useruid} --gid ${usergid} -m ${username} \
 #
-# and add sudoers for install library post docker operation
+# コンテナ上でsudoをパスワードなしで実行できるように対応
 && apt-get update \
 && apt-get install -y sudo \
 && echo ${username} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${username} \
 && chmod 0440 /etc/sudoers.d/${username} \
 #
-# for prisma
+# prismaに必要
 && apt-get install -y openssl
 
 USER ${username}
 WORKDIR /app
 
-# for bun
+# ライブラリインストール
 COPY --chown=${username}:${username} package.json ./
 COPY --chown=${username}:${username} bun.lockb ./
 RUN bun install
 
-# copies rest of application code
+# アプリケーションコードをコピー
 COPY --chown=${username}:${username} . .
+
+# パフォーマンス向上のため、vercelへの情報提供を抑止
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN bunx prisma generate
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,47 @@
+services:
+  postgres:
+    image: postgres:16.8-alpine3.21
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DATABASE=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_ROOT_PASSWORD=root
+    healthcheck:
+      test: pg_isready -U postgres -d postgres
+      interval: 3s
+      timeout: 3s
+      retries: 5
+
+  app:
+    build:
+      context: '.'
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    command: >
+      sh -c "bunx prisma migrate deploy && bun start"
+    user: vscode
+    environment:
+      - POSTGRES_PRISMA_URL=postgres://postgres:password@postgres:5432/postgres?pgbouncer=true&connect_timeout=15
+      - POSTGRES_URL_NON_POOLING=postgres://postgres:password@postgres:5432/postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  e2e:
+    build:
+      context: ./
+      dockerfile: ./e2e/Dockerfile
+    environment:
+      - CI=${CI}
+      - PLAYWRIGHT_BASE_URL=http://app:3000
+      - POSTGRES_PRISMA_URL=postgres://postgres:password@postgres:5432/postgres?pgbouncer=true&connect_timeout=15
+      - POSTGRES_URL_NON_POOLING=postgres://postgres:password@postgres:5432/postgres
+    volumes:
+      - ./test-results:/app/test-results
+    ports:
+      - "9323:9323"
+    depends_on:
+      - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
 services:
   postgres:
     container_name: postgres
-    image: postgres:16.4-alpine3.20
+    image: postgres:16.8-alpine3.21
     volumes:
       - pg-data:/var/lib/postgresql/data
       - type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ volumes:
 
 services:
   postgres:
-    container_name: postgres
     image: postgres:16.8-alpine3.21
     volumes:
       - pg-data:/var/lib/postgresql/data

--- a/e2e/.dockerignore
+++ b/e2e/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.env
+
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.env
+
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/playwright:v1.52.0
+
+EXPOSE 9323
+WORKDIR /app
+
+COPY ./e2e/package*.json .
+RUN npm ci
+
+COPY ./e2e .
+COPY ../prisma ./prisma
+RUN npx prisma generate
+
+CMD ["npm", "test"]

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,113 @@
+{
+  "name": "e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.51.1",
+        "@prisma/client": "^6.3.1",
+        "@types/node": "20.14.8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.6.0.tgz",
+      "integrity": "sha512-vfp73YT/BHsWWOAuthKQ/1lBgESSqYqAWZEYyTdGXyFAHpmewwWL2Iz6ErIzkj4aHbuc6/cGSsE6ZY+pBO04Cg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "e2e",
+  "version": "0.0.0",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.51.1",
+    "@prisma/client": "^6.3.1",
+    "@types/node": "20.14.8"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,89 @@
+import { defineConfig, devices } from "@playwright/test";
+// import dotenv from "dotenv";
+// import dotenvExpand from "dotenv-expand";
+// import path from "path";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// dotenvExpand.expand(dotenv.config({ path: path.resolve(__dirname, ".env") }));
+// override per environment
+// if (process.env.TEST_ENV) {
+//   dotenv.config({
+//     path: path.resolve(__dirname, `.env.${process.env.TEST_ENV}`),
+//     override: true,
+//   });
+// }
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI
+    ? [["html", { open: "never" }]]
+    : [["html", { host: "0.0.0.0", port: "9323", open: "always" }]],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */ use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.PLAYWRIGHT_BASE_URL,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
+
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});


### PR DESCRIPTION
This pull request introduces several changes to enhance Docker-based development workflows and adds support for end-to-end (E2E) testing using Playwright. Key updates include improvements to Docker configurations, the addition of a new `docker-compose.e2e.yml` file for E2E testing, and the setup of Playwright for automated browser testing.

### Docker and Docker Compose Improvements:
* Updated the `Dockerfile` to add a non-root user (`vscode`), set permissions for copied files, and disable telemetry for performance improvement.
* Added `docker-compose.e2e.yml` to define services for E2E testing, including `postgres`, `app`, and `e2e` services, with health checks and environment variables for database connectivity.
* Updated the `postgres` service in `docker-compose.yml` to use a newer image version (`postgres:16.8-alpine3.21`).

### E2E Testing Setup:
* Added a new `e2e/Dockerfile` to build a Playwright-based testing container.
* Configured Playwright with a `playwright.config.ts` file, enabling parallel test execution, retries in CI, and support for Chromium browser testing.

### Dependency Management and Ignored Files:
* Added `e2e/package.json` and `e2e/package-lock.json` to manage dependencies for Playwright and Prisma. [[1]](diffhunk://#diff-a02b008b50077ce0795c0dee89c3b663ead543e6d790874baece325aee7f1043R1-R12) [[2]](diffhunk://#diff-139617765b1e6e524ac53308ebacd758a4cef34c596b47f4ac3688652fd49518R1-R113)
* Updated `.dockerignore` and `.gitignore` in the `e2e` directory to exclude unnecessary files and directories, such as `node_modules` and test reports.